### PR TITLE
Adds rule to enforce semi-colons

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -27,6 +27,7 @@
     "padded-blocks": ["error", "never"],
     "space-before-function-paren": ["error", "never"],
     "space-in-parens": ["error", "never"],
+    "semi": ["error", "always"],
     "strict": "off",
     "no-undef": "off",
     "react/react-in-jsx-scope": "error",


### PR DESCRIPTION
Get those semi's in there:

**NO**
```js
var name = "ESLint"

object.method = function() {
    // ...
}
```

**YES**
```js
var name = "ESLint";

object.method = function() {
    // ...
};
```