### PR TITLE
Feature/no bitwise

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -30,7 +30,7 @@
     "semi": ["error", "always"],
     "strict": "off",
     "no-undef": "off",
-    "no-bitwise": ["error"],
+    "no-bitwise": "error",
     "react/react-in-jsx-scope": "error",
     "react/jsx-uses-react": "error",
     "react/jsx-uses-vars": "error",

--- a/eslintrc.json
+++ b/eslintrc.json
@@ -30,6 +30,7 @@
     "semi": ["error", "always"],
     "strict": "off",
     "no-undef": "off",
+    "no-bitwise": ["error"],
     "react/react-in-jsx-scope": "error",
     "react/jsx-uses-react": "error",
     "react/jsx-uses-vars": "error",


### PR DESCRIPTION
This rule just enforses using things like `&&` and `||`.
https://eslint.org/docs/rules/no-bitwise