### PR TITLE
Overrides max-nested-callbacks for tests

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -35,8 +35,17 @@
     "react/react-in-jsx-scope": "error",
     "react/jsx-uses-react": "error",
     "react/jsx-uses-vars": "error",
-    "max-nested-callbacks": ["error", 6]
+    "max-nested-callbacks": ["error", 3]
   },
+
+  "overrides": [
+    {
+      "files": [ "test/**/*.js" ],
+      "rules": {
+        "max-nested-callbacks": ["error", 4],
+      }
+    }
+  ],
 
   "plugins": [
     "react"


### PR DESCRIPTION
Reverts to 3 nested callbacks, but overrides the value for tests specifically.

See https://eslint.org/docs/user-guide/configuring#configuration-based-on-glob-patterns for config docs